### PR TITLE
fix: use ErrHelp for help usage

### DIFF
--- a/command.go
+++ b/command.go
@@ -130,7 +130,10 @@ func helpErr(c *Command) error {
 		help = c.Long
 	}
 
-	return fmt.Errorf("%s\n\n%s", help, c.Usage())
+	return ErrHelp{
+		Message: help,
+		usage:   c.Usage(),
+	}
 }
 
 // Name of this command. The first segment of the `Use` field.

--- a/help.go
+++ b/help.go
@@ -16,19 +16,26 @@ func (c *Command) help(reason error) error {
 	}
 
 	return ErrHelp{
-		Reason: reason,
-		usage:  c.Usage(),
+		Message: reason.Error(),
+		usage:   c.Usage(),
+		error:   true,
 	}
 }
 
 // ErrHelp wraps an actual error, showing the usage of the command afterwards
 type ErrHelp struct {
-	Reason error
-	usage  string
+	Message string
+	usage   string
+	error   bool
 }
 
 func (e ErrHelp) Error() string {
-	return fmt.Sprintf("Error: %s\n\n%s", e.Reason.Error(), e.usage)
+	pat := "%s\n\n%s"
+	if e.error {
+		pat = "Error: " + pat
+	}
+
+	return fmt.Sprintf(pat, e.Message, e.usage)
 }
 
 // helpable is a internal wrapper type of Command that defines functions


### PR DESCRIPTION
Also uses the `ErrHelp` type for printing the command usage in case of
explicit request (`-h` or no args).

This allows the error to be caught and differently handled, e.g. printed
using `fmt` instead of `log`, to avoid timestamps, etc.