### PR TITLE
fix: don't attempt to bind -h if already bound

### DIFF
--- a/command.go
+++ b/command.go
@@ -121,6 +121,11 @@ func (c *Command) execute(args []string) error {
 }
 
 func initHelpFlag(c *Command) *bool {
+	if f := c.Flags().ShorthandLookup("h"); f != nil {
+		// -h already taken, so don't try to bind it
+		return c.Flags().Bool("help", false, "help for "+c.Name())
+	}
+
 	return c.Flags().BoolP("help", "h", false, "help for "+c.Name())
 }
 


### PR DESCRIPTION
Binding a flag that already exists leads to a `panic`. While we did
check whether `--help` was bound, we did not check for the edge case
where `--help` is indeed unbound, but its shorthand `-h` was not.

This is now safely checked, so when the edge-case occurs, only the long
form will be bound.