### PR TITLE
Export Commands

### DIFF
--- a/children.go
+++ b/children.go
@@ -7,7 +7,7 @@ import "fmt"
 func (c *Command) AddCommand(children ...*Command) {
 	for _, child := range children {
 		child.parentPtr = c
-		c.children = append(c.children, child)
+		c.Commands = append(c.Commands, child)
 	}
 }
 
@@ -21,7 +21,7 @@ func findTarget(c *Command, args []string) (*Command, []string, error) {
 
 	cmd, ok := c.child(nextSubCmd)
 	switch {
-	case !ok && c.children != nil:
+	case !ok && c.Commands != nil:
 		return nil, nil, c.help(fmt.Errorf("unknown subcommand `%s`", nextSubCmd))
 	case cmd != nil:
 		return findTarget(cmd, argsMinusFirstX(args, nextSubCmd))
@@ -30,7 +30,7 @@ func findTarget(c *Command, args []string) (*Command, []string, error) {
 }
 
 func (c *Command) child(name string) (*Command, bool) {
-	for _, child := range c.children {
+	for _, child := range c.Commands {
 		if child.Name() == name {
 			return child, true
 		}

--- a/command.go
+++ b/command.go
@@ -42,8 +42,10 @@ type Command struct {
 	// Args is used to validate and complete positional arguments
 	Args Arguments
 
+	// Child commands
+	Commands []*Command
+
 	// internal fields
-	children  []*Command
 	flags     *pflag.FlagSet
 	parentPtr *Command
 }
@@ -58,7 +60,7 @@ func (c *Command) Execute() error {
 	}
 
 	// add subcommand for install CLI completions
-	if len(c.children) != 0 {
+	if len(c.Commands) != 0 {
 		c.AddCommand(completionCmd(c.Use))
 	}
 

--- a/command.go
+++ b/command.go
@@ -127,18 +127,6 @@ func initHelpFlag(c *Command) *bool {
 	return c.Flags().BoolP("help", "h", false, "help for "+c.Name())
 }
 
-func helpErr(c *Command) error {
-	help := c.Short
-	if c.Long != "" {
-		help = c.Long
-	}
-
-	return ErrHelp{
-		Message: help,
-		usage:   c.Usage(),
-	}
-}
-
 // Name of this command. The first segment of the `Use` field.
 func (c *Command) Name() string {
 	return strings.Split(c.Use, " ")[0]

--- a/help.go
+++ b/help.go
@@ -95,7 +95,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.
 // texts line up
 func (h *helpable) CommandPadding() int {
 	pad := 9
-	for _, c := range h.parentPtr.children {
+	for _, c := range h.parentPtr.Commands {
 		l := len(c.Name())
 		if l > pad {
 			pad = l
@@ -117,13 +117,13 @@ func (h *helpable) Use() string {
 
 // HasChildren reports whether this command has children
 func (h *helpable) HasChildren() bool {
-	return h.children != nil
+	return h.Commands != nil
 }
 
 // Children returns the children of this command.
 func (h *helpable) Children() []*helpable {
-	m := make([]*helpable, len(h.children))
-	for i, c := range h.children {
+	m := make([]*helpable, len(h.Commands))
+	for i, c := range h.Commands {
 		m[i] = c.helpable()
 	}
 	return m

--- a/predict.go
+++ b/predict.go
@@ -42,15 +42,15 @@ func createCmp(c *Command) complete.Command {
 		rootCmp.Flags["--"+flag.Name] = p
 	})
 
-	if c.children != nil {
+	if c.Commands != nil {
 		rootCmp.Sub = make(complete.Commands)
-		for _, child := range c.children {
+		for _, child := range c.Commands {
 			rootCmp.Sub[child.Name()] = createCmp(child)
 		}
 	}
 
 	// Positional Arguments, default to ArgsAny for all leaf commands
-	if c.Args == nil && len(c.children) == 0 {
+	if c.Args == nil && len(c.Commands) == 0 {
 		c.Args = ArgsAny()
 	}
 	rootCmp.Args = c.Args


### PR DESCRIPTION
I'd like to propose we export child commands on the [Command](https://pkg.go.dev/github.com/go-clix/cli#Command) type.

My use case is generating a centralized help document for all commands. I tend to find myself creating this manually and it's always outdated.

<details>
<summary>This is an example of how to accomplish something like this with my proposed changes...</summary>

```go
package main

import (
	"fmt"
	"strings"

	"github.com/go-clix/cli"
)

func allhelpCmd(rootCmd *cli.Command) *cli.Command {

	cmd := &cli.Command{
		Use:   "allhelp",
		Short: "Output help for all commands",
	}

	cmd.Run = func(cmd *cli.Command, args []string) error {

		cmdSegments := map[int]string{}

		var buildHelp func(cli.Command, int)
		buildHelp = func(c cli.Command, level int) {

			cmdSegments[level] = c.Use

			var fullCmd []string
			for i := 0; i <= level; i++ {
				fullCmd = append(fullCmd, cmdSegments[i])
			}
			fmt.Println(strings.Join(fullCmd, " "))
			fmt.Println(c.Short)
			fmt.Println(c.Long)
			fmt.Println(c.Flags().FlagUsages())

			for _, childCmd := range c.Commands {
				buildHelp(*childCmd, level+1)
			}
		}

		buildHelp(*rootCmd, 0)

		return nil
	}

	return cmd
}
```

</details>

#### Implementation Details

I've renamed to the field from `children` to `Commands`. I've avoided `Children` because this conflicts with [helpable](https://github.com/go-clix/cli/blob/6e2d8d038d677555eaebe90a1db2951aed61ad40/help.go#L41-L45) that uses `Command` as an anonymous field and also implements a [`Children` method](https://github.com/go-clix/cli/blob/6e2d8d038d677555eaebe90a1db2951aed61ad40/help.go#L123-L130).

#### Notes

I've also removed the `helpErr` function because it's not used anywhere. This was also the only place that references the `Long` field which is intended to be "used for full help pages". Exporting child commands would facilitate usage of this field.